### PR TITLE
Gravatar option

### DIFF
--- a/roles/taiga-front/defaults/main.yml
+++ b/roles/taiga-front/defaults/main.yml
@@ -19,3 +19,6 @@ taiga_front_debug: "{{ taiga_debug }}"
 
 # Do we want to expose the Django admin interface in the front end?
 taiga_front_enable_django_admin: false
+
+# Enable/Disable taiga front gravatar support
+taiga_front_gravatar_enabled: true

--- a/roles/taiga-front/templates/conf.json.j2
+++ b/roles/taiga-front/templates/conf.json.j2
@@ -30,5 +30,5 @@
 	],
 	"tribeHost": null,
 	"importers": [],
-	"gravatar": true
+	"gravatar": {{ taiga_front_gravatar_enabled | lower }}
 }

--- a/variables.md
+++ b/variables.md
@@ -411,6 +411,9 @@ taiga_front_debug: "{{ taiga_debug }}"
 # Do we want to expose the Django admin interface in the front end?
 taiga_front_enable_django_admin: false
 
+# Enable/Disable taiga front gravatar support
+taiga_front_gravatar_enabled: true
+
 ```
 
 ## Variables defined in `taiga-back`


### PR DESCRIPTION
Add option to enable/disable gravatar. 

Added taiga_front_gravatar_enabled to taiga-front role. This is used in the conf.json.j2 template to change the gravatar setting. 