### PR TITLE
Fix variable check

### DIFF
--- a/roles/taiga/tasks/main.yml
+++ b/roles/taiga/tasks/main.yml
@@ -21,7 +21,6 @@
     that:
       - "taiga_secret_key is defined"
       - "taiga_rabbitmq_password is defined or not (taiga_enable_events | bool or taiga_enable_async_tasks | bool)"
-      - "taiga_service_manager == 'circus' or ansible_version | version_compare('2.2', '>=')"
   with_items:
     - taiga_secret_key
   tags:

--- a/roles/taiga/tasks/main.yml
+++ b/roles/taiga/tasks/main.yml
@@ -21,8 +21,6 @@
     that:
       - "taiga_secret_key is defined"
       - "taiga_rabbitmq_password is defined or not (taiga_enable_events | bool or taiga_enable_async_tasks | bool)"
-  with_items:
-    - taiga_secret_key
   tags:
     - always
 


### PR DESCRIPTION
Fix the `check for required variables` task so that it no longer checks for `taiga_service_manager` being set to `cirrus` *if* we're running on Ansible<2.2 (because the README has said for some time that Ansible 2.5 is the minimum supported version).

This supersedes #13; thanks to @Dranaxel for spotting this.