### PR TITLE
Import config overrides from local.py

### DIFF
--- a/roles/taiga-back/tasks/main.yml
+++ b/roles/taiga-back/tasks/main.yml
@@ -115,6 +115,18 @@
     - back-config
     - offline
 
+- name: adjust settings.py to import local
+  become: true
+  become_user: "{{ taiga_user }}"
+  lineinfile:
+    path: "{{ taiga_user_home }}/{{ taiga_back_checkout_dir }}/settings/common.py"
+    line: 'from settings.local import *'
+    insertbefore: "# NOTE: DON'T INSERT ANYTHING AFTER THIS BLOCK"
+  tags:
+    - config
+    - back-config
+    - offline
+
 - name: optionally deploy local Celery settings
   become: true
   become_user: "{{ taiga_user }}"


### PR DESCRIPTION
It seems that nowadays Taiga doesn't try to load config overrides from
local.py which results in DB migration issue, since it try to use
password auth instead of peer one.

By adding this task we explicitly import overrides after all defaults
are set.