### PR TITLE
Make PYTHONPATH for circus universal

### DIFF
--- a/roles/taiga-back/tasks/circus.yml
+++ b/roles/taiga-back/tasks/circus.yml
@@ -1,3 +1,15 @@
+---
+
+- name: register gunicorn lib path
+  become: true
+  become_user: "{{ taiga_user }}"
+  command: "{{ taiga_user_home }}/{{ taiga_back_venv_dir }}/bin/python3 -c 'import gunicorn; print(gunicorn.__file__)'"
+  register: _gunicorn_path
+  tags:
+    - config
+    - back-config
+    - offline
+
 - name: add taiga to Circus
   become: true
   become_user: "{{ taiga_user }}"

--- a/roles/taiga-back/tasks/circus.yml
+++ b/roles/taiga-back/tasks/circus.yml
@@ -5,6 +5,7 @@
   become_user: "{{ taiga_user }}"
   command: "{{ taiga_user_home }}/{{ taiga_back_venv_dir }}/bin/python3 -c 'import gunicorn; print(gunicorn.__file__)'"
   register: _gunicorn_path
+  changed_when: false
   tags:
     - config
     - back-config

--- a/roles/taiga-back/templates/taiga-celery.ini.j2
+++ b/roles/taiga-back/templates/taiga-celery.ini.j2
@@ -22,4 +22,4 @@ SHELL=/bin/bash
 USER={{ taiga_user }}
 LANG=en_US.UTF-8
 HOME=/home/taiga
-PYTHONPATH={{ taiga_user_home }}/{{ taiga_back_venv_dir }}/lib/python3.5/site-packages
+PYTHONPATH={{ _gunicorn_path.stdout | dirname | dirname }}

--- a/roles/taiga-back/templates/taiga.ini.j2
+++ b/roles/taiga-back/templates/taiga.ini.j2
@@ -23,4 +23,4 @@ SHELL=/bin/bash
 USER={{ taiga_user }}
 LANG=en_US.UTF-8
 HOME={{ taiga_user_home }}
-PYTHONPATH={{ taiga_user_home }}/{{ taiga_back_venv_dir }}/lib/python3.5/site-packages
+PYTHONPATH={{ _gunicorn_path.stdout | dirname | dirname }}


### PR DESCRIPTION
Currently PYTHONPATH is hardcoded and assumption about
python version is made. While its recommended to use systemd,
we still can fix circus by retrieving venv lib path.
As a package location we pick gunicorn as smth we expect to
be present anyway. As a result we will get
{{ lib_path }}/gunicorn/__init__.py so we apply dirname twice to get
just lib_path that can be re-used later on