### PR TITLE
Add taiga_node_version variable

### DIFF
--- a/generate-variables-md.sh
+++ b/generate-variables-md.sh
@@ -6,7 +6,7 @@ cat <<'EOF'
 # Overridable variables defined for `ansible-taiga`
 EOF
 
-for role in taiga{,-webserver,-front,-back,-events}; do
+for role in taiga{,-webserver,-front,-back,-events,-node}; do
     role_defaults_file="roles/$role/defaults/main.yml"
     if [ -e $role_defaults_file ]; then
 	echo

--- a/roles/taiga-node/defaults/main.yml
+++ b/roles/taiga-node/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Repo release of nodeJS to be installed.
+taiga_node_version: 8

--- a/roles/taiga-node/tasks/main.yml
+++ b/roles/taiga-node/tasks/main.yml
@@ -23,7 +23,7 @@
   become: true
   become_user: root
   apt_repository:
-    repo: "deb https://deb.nodesource.com/node_8.x {{ ansible_distribution_release }} main"
+    repo: "deb https://deb.nodesource.com/node_{{ taiga_node_version | default('8') }}.x {{ ansible_distribution_release }} main"
   register: nodesource_repo
   tags:
     - install

--- a/roles/taiga-node/tasks/main.yml
+++ b/roles/taiga-node/tasks/main.yml
@@ -23,7 +23,7 @@
   become: true
   become_user: root
   apt_repository:
-    repo: "deb https://deb.nodesource.com/node_{{ taiga_node_version | default('8') }}.x {{ ansible_distribution_release }} main"
+    repo: "deb https://deb.nodesource.com/node_{{ taiga_node_version }}.x {{ ansible_distribution_release }} main"
   register: nodesource_repo
   tags:
     - install

--- a/variables.md
+++ b/variables.md
@@ -505,3 +505,11 @@ taiga_events_version: "master"  # No stable branch exists for taiga-events
 taiga_events_log_dir: "{{ taiga_log_dir }}"
 
 ```
+
+## Variables defined in `taiga-node`
+
+```yaml
+---
+# Version of nodeJS to be installed.
+taiga_node_version: 8
+```

--- a/variables.md
+++ b/variables.md
@@ -510,6 +510,7 @@ taiga_events_log_dir: "{{ taiga_log_dir }}"
 
 ```yaml
 ---
-# Version of nodeJS to be installed.
+# Repo release of nodeJS to be installed.
 taiga_node_version: 8
+
 ```


### PR DESCRIPTION
We add variable to configure version of nodeJS to be installed.
For example, nodJS 8 repo does not inlcude Ubuntu 20.04 packages,
so it might be good idea to override version to allow
deployers locally bump node version.