### PR TITLE
Fix rabbit/redis conditions

### DIFF
--- a/roles/taiga-back/tasks/main.yml
+++ b/roles/taiga-back/tasks/main.yml
@@ -52,8 +52,8 @@
 
 - name: set facts identifying backend services
   set_fact:
-    _taiga_is_rabbit_node: "(taiga_enable_async_tasks | bool or taiga_enable_events | bool) and (taiga_rabbitmq_host in ['localhost', '127.0.0.1', '::1', ansible_hostname, ansible_fqdn])"   # noqa 204
-    _taiga_is_redis_node: "(taiga_enable_async_tasks | bool) and (taiga_back_redis_host in ['localhost', '127.0.0.1', '::1', ansible_hostname, ansible_fqdn])"   # noqa 204
+    _taiga_is_rabbit_node: "{{ (taiga_enable_async_tasks | bool or taiga_enable_events | bool) and (taiga_rabbitmq_host in ['localhost', '127.0.0.1', '::1', ansible_hostname, ansible_fqdn]) }}"   # noqa 204
+    _taiga_is_redis_node: "{{ (taiga_enable_async_tasks | bool) and (taiga_back_redis_host in ['localhost', '127.0.0.1', '::1', ansible_hostname, ansible_fqdn]) }}"   # noqa 204
   tags: always
 
 - include: rabbitmq.yml


### PR DESCRIPTION
It seems that during moving conditions from inlcude to independent
set_fact task, setting them as variables has been missed.